### PR TITLE
Adds authentication layer to frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.log

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -22,7 +22,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = config('SECRET_KEY', default='django-insecure-eyiudt)c4efbabjqea@k^+od%p0a@rmw+v6%ys9+dn0tq%z_ga')
+SECRET_KEY = config(
+    'SECRET_KEY', default='django-insecure-eyiudt)c4efbabjqea@k^+od%p0a@rmw+v6%ys9+dn0tq%z_ga')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = config('DEBUG', default=False, cast=bool)
@@ -44,6 +45,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.gis',
     'rest_framework',
+    'rest_framework.authtoken',
     'rest_framework_gis',
     'lending_library',
     'django_filters',
@@ -157,7 +159,7 @@ STORAGES = {
     },
     'staticfiles': {
         # Leave whatever setting you already have here, e.g.:
-       # 'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+        # 'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
         'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
     }
 }
@@ -167,7 +169,7 @@ AWS_S3_ACCESS_KEY_ID = config('AWS_S3_ACCESS_KEY_ID', default='')
 AWS_S3_SECRET_ACCESS_KEY = config('AWS_S3_SECRET_ACCESS_KEY', default='')
 AWS_STORAGE_BUCKET_NAME = config('AWS_STORAGE_BUCKET_NAME', default='')
 AWS_S3_REGION_NAME = config('AWS_S3_REGION_NAME', default='')
-#AWS_DEFAULT_ACL = 'public-read'
-#AWS_S3_CUSTOM_DOMAIN = 'media.commonplace.tools'
-#MEDIA_URL = 'http://media.commonplace.tools/'
+# AWS_DEFAULT_ACL = 'public-read'
+# AWS_S3_CUSTOM_DOMAIN = 'media.commonplace.tools'
+# MEDIA_URL = 'http://media.commonplace.tools/'
 AWS_QUERYSTRING_AUTH = False

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -19,7 +19,8 @@ from django.urls import path
 from django.conf.urls import include
 from filebrowser.sites import site
 from rest_framework import routers
-from lending_library.views import LoanViewSet 
+from rest_framework.authtoken import views
+from lending_library.views import LoanViewSet
 from lending_library.views import LocationViewSet
 from lending_library.views import NetworkViewSet
 from lending_library.views import LendableTypeViewSet
@@ -28,7 +29,6 @@ from lending_library.views import LendableViewSet
 from lending_library.views import LoanViewSet
 from lending_library.views import UserViewSet
 from lending_library.views import GroupViewSet, PermissionViewSet, ContentTypeViewSet
-
 
 
 router = routers.DefaultRouter()
@@ -46,9 +46,12 @@ router.register(r'contenttype', ContentTypeViewSet)
 
 urlpatterns = [
     path('admin/filebrowser/', site.urls),
-    path('grappelli/', include('grappelli.urls')), # grappelli URLS
+    path('grappelli/', include('grappelli.urls')),  # grappelli URLS
     path('admin/', admin.site.urls),
 
     path('', include(router.urls)),
+
+    path('api-token-auth/', views.obtain_auth_token),
+
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework'))
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,8 @@ services:
       - static:/static
     expose:
       - "8000"
+    ports:
+      - "8000:8000"
     environment:
       - POSTGRES_NAME=postgres
       - POSTGRES_USER=postgres
@@ -112,6 +114,8 @@ services:
       dockerfile: ./Dockerfile
     expose:
       - "3000"
+    ports:
+      - "3000:3000"
     depends_on:
       - backend-local
       - nginx-proxy-local

--- a/next-frontend/package-lock.json
+++ b/next-frontend/package-lock.json
@@ -18,7 +18,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sharp": "^0.32.6",
-        "typescript": "5.2.2"
+        "typescript": "5.2.2",
+        "zod": "^3.22.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3889,6 +3890,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/next-frontend/package-lock.json
+++ b/next-frontend/package-lock.json
@@ -13,10 +13,10 @@
         "@types/react-dom": "18.2.14",
         "classnames": "^2.3.2",
         "eslint": "8.52.0",
-        "eslint-config-next": "13.5.6",
-        "next": "13.5.6",
-        "react": "18.2.0",
-        "react-dom": "18.2.0",
+        "eslint-config-next": "^14.0.4",
+        "next": "^14.0.4",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "sharp": "^0.32.6",
         "typescript": "5.2.2"
       }
@@ -123,22 +123,22 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw=="
     },
     "node_modules/@next/env": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
-      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw=="
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.4.tgz",
+      "integrity": "sha512-irQnbMLbUNQpP1wcE5NstJtbuA/69kRfzBrpAD7Gsn8zm/CY6YQYc3HQBz8QPxwISG26tIm5afvvVbu508oBeQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.5.6.tgz",
-      "integrity": "sha512-ng7pU/DDsxPgT6ZPvuprxrkeew3XaRf4LAT4FabaEO/hAbvVx4P7wqnqdbTdDn1kgTvsI4tpIgT4Awn/m0bGbg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.0.4.tgz",
+      "integrity": "sha512-U3qMNHmEZoVmHA0j/57nRfi3AscXNvkOnxDmle/69Jz/G0o/gWjXTDdlgILZdrxQ0Lw/jv2mPW8PGy0EGIHXhQ==",
       "dependencies": {
         "glob": "7.1.7"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.6.tgz",
-      "integrity": "sha512-5nvXMzKtZfvcu4BhtV0KH1oGv4XEW+B+jOfmBdpFI3C7FrB/MfujRpWYSBBO64+qbW8pkZiSyQv9eiwnn5VIQA==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.0.4.tgz",
+      "integrity": "sha512-mF05E/5uPthWzyYDyptcwHptucf/jj09i2SXBPwNzbgBNc+XnwzrL0U6BmPjQeOL+FiB+iG1gwBeq7mlDjSRPg==",
       "cpu": [
         "arm64"
       ],
@@ -151,9 +151,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.6.tgz",
-      "integrity": "sha512-6cgBfxg98oOCSr4BckWjLLgiVwlL3vlLj8hXg2b+nDgm4bC/qVXXLfpLB9FHdoDu4057hzywbxKvmYGmi7yUzA==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.0.4.tgz",
+      "integrity": "sha512-IZQ3C7Bx0k2rYtrZZxKKiusMTM9WWcK5ajyhOZkYYTCc8xytmwSzR1skU7qLgVT/EY9xtXDG0WhY6fyujnI3rw==",
       "cpu": [
         "x64"
       ],
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.6.tgz",
-      "integrity": "sha512-txagBbj1e1w47YQjcKgSU4rRVQ7uF29YpnlHV5xuVUsgCUf2FmyfJ3CPjZUvpIeXCJAoMCFAoGnbtX86BK7+sg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.0.4.tgz",
+      "integrity": "sha512-VwwZKrBQo/MGb1VOrxJ6LrKvbpo7UbROuyMRvQKTFKhNaXjUmKTu7wxVkIuCARAfiI8JpaWAnKR+D6tzpCcM4w==",
       "cpu": [
         "arm64"
       ],
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.6.tgz",
-      "integrity": "sha512-cGd+H8amifT86ZldVJtAKDxUqeFyLWW+v2NlBULnLAdWsiuuN8TuhVBt8ZNpCqcAuoruoSWynvMWixTFcroq+Q==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.0.4.tgz",
+      "integrity": "sha512-8QftwPEW37XxXoAwsn+nXlodKWHfpMaSvt81W43Wh8dv0gkheD+30ezWMcFGHLI71KiWmHK5PSQbTQGUiidvLQ==",
       "cpu": [
         "arm64"
       ],
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.6.tgz",
-      "integrity": "sha512-Mc2b4xiIWKXIhBy2NBTwOxGD3nHLmq4keFk+d4/WL5fMsB8XdJRdtUlL87SqVCTSaf1BRuQQf1HvXZcy+rq3Nw==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.0.4.tgz",
+      "integrity": "sha512-/s/Pme3VKfZAfISlYVq2hzFS8AcAIOTnoKupc/j4WlvF6GQ0VouS2Q2KEgPuO1eMBwakWPB1aYFIA4VNVh667A==",
       "cpu": [
         "x64"
       ],
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.6.tgz",
-      "integrity": "sha512-CFHvP9Qz98NruJiUnCe61O6GveKKHpJLloXbDSWRhqhkJdZD2zU5hG+gtVJR//tyW897izuHpM6Gtf6+sNgJPQ==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.0.4.tgz",
+      "integrity": "sha512-m8z/6Fyal4L9Bnlxde5g2Mfa1Z7dasMQyhEhskDATpqr+Y0mjOBZcXQ7G5U+vgL22cI4T7MfvgtrM2jdopqWaw==",
       "cpu": [
         "x64"
       ],
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.6.tgz",
-      "integrity": "sha512-aFv1ejfkbS7PUa1qVPwzDHjQWQtknzAZWGTKYIAaS4NMtBlk3VyA6AYn593pqNanlicewqyl2jUhQAaFV/qXsg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.0.4.tgz",
+      "integrity": "sha512-7Wv4PRiWIAWbm5XrGz3D8HUkCVDMMz9igffZG4NB1p4u1KoItwx9qjATHz88kwCEal/HXmbShucaslXCQXUM5w==",
       "cpu": [
         "arm64"
       ],
@@ -241,9 +241,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.6.tgz",
-      "integrity": "sha512-XqqpHgEIlBHvzwG8sp/JXMFkLAfGLqkbVsyN+/Ih1mR8INb6YCc2x/Mbwi6hsAgUnqQztz8cvEbHJUbSl7RHDg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.0.4.tgz",
+      "integrity": "sha512-zLeNEAPULsl0phfGb4kdzF/cAVIfaC7hY+kt0/d+y9mzcZHsMS3hAS829WbJ31DkSlVKQeHEjZHIdhN+Pg7Gyg==",
       "cpu": [
         "ia32"
       ],
@@ -256,9 +256,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.6.tgz",
-      "integrity": "sha512-Cqfe1YmOS7k+5mGu92nl5ULkzpKuxJrP3+4AEuPmrpFZ3BHxTY3TnHmU1On3bFmFFs6FbTcdF58CCUProGpIGQ==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.0.4.tgz",
+      "integrity": "sha512-yEh2+R8qDlDCjxVpzOTEpBLQTEFAcP2A8fUFLaWNap9GitYKkKv1//y2S6XY6zsR4rCOPRpU7plYDR+az2n30A==",
       "cpu": [
         "x64"
       ],
@@ -1228,11 +1228,11 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.5.6.tgz",
-      "integrity": "sha512-o8pQsUHTo9aHqJ2YiZDym5gQAMRf7O2HndHo/JZeY7TDD+W4hk6Ma8Vw54RHiBeb7OWWO5dPirQB+Is/aVQ7Kg==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.0.4.tgz",
+      "integrity": "sha512-9/xbOHEQOmQtqvQ1UsTQZpnA7SlDMBtuKJ//S4JnoyK3oGLhILKXdBgu/UO7lQo/2xOykQULS1qQ6p2+EpHgAQ==",
       "dependencies": {
-        "@next/eslint-plugin-next": "13.5.6",
+        "@next/eslint-plugin-next": "14.0.4",
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -2581,14 +2581,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/next": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.5.6.tgz",
-      "integrity": "sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==",
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.0.4.tgz",
+      "integrity": "sha512-qbwypnM7327SadwFtxXnQdGiKpkuhaRLE2uq62/nRul9cj9KhQ5LhHmlziTNqUidZotw/Q1I9OjirBROdUJNgA==",
       "dependencies": {
-        "@next/env": "13.5.6",
+        "@next/env": "14.0.4",
         "@swc/helpers": "0.5.2",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
+        "graceful-fs": "^4.2.11",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.1",
         "watchpack": "2.4.0"
@@ -2597,18 +2598,18 @@
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=16.14.0"
+        "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.5.6",
-        "@next/swc-darwin-x64": "13.5.6",
-        "@next/swc-linux-arm64-gnu": "13.5.6",
-        "@next/swc-linux-arm64-musl": "13.5.6",
-        "@next/swc-linux-x64-gnu": "13.5.6",
-        "@next/swc-linux-x64-musl": "13.5.6",
-        "@next/swc-win32-arm64-msvc": "13.5.6",
-        "@next/swc-win32-ia32-msvc": "13.5.6",
-        "@next/swc-win32-x64-msvc": "13.5.6"
+        "@next/swc-darwin-arm64": "14.0.4",
+        "@next/swc-darwin-x64": "14.0.4",
+        "@next/swc-linux-arm64-gnu": "14.0.4",
+        "@next/swc-linux-arm64-musl": "14.0.4",
+        "@next/swc-linux-x64-gnu": "14.0.4",
+        "@next/swc-linux-x64-musl": "14.0.4",
+        "@next/swc-win32-arm64-msvc": "14.0.4",
+        "@next/swc-win32-ia32-msvc": "14.0.4",
+        "@next/swc-win32-x64-msvc": "14.0.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/next-frontend/package.json
+++ b/next-frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@types/node": "20.8.7",
@@ -19,6 +20,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sharp": "^0.32.6",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "zod": "^3.22.4"
   }
 }

--- a/next-frontend/package.json
+++ b/next-frontend/package.json
@@ -14,10 +14,10 @@
     "@types/react-dom": "18.2.14",
     "classnames": "^2.3.2",
     "eslint": "8.52.0",
-    "eslint-config-next": "13.5.6",
-    "next": "13.5.6",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
+    "eslint-config-next": "^14.0.4",
+    "next": "^14.0.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "sharp": "^0.32.6",
     "typescript": "5.2.2"
   }

--- a/next-frontend/src/app/api/token/route.ts
+++ b/next-frontend/src/app/api/token/route.ts
@@ -1,0 +1,13 @@
+/* Provide a method for a client to fetch the server's session token cookie, if it exists. */
+import { redirect } from "next/navigation";
+import { getToken, deleteToken } from "src/app/auth/actions";
+
+export async function GET() {
+  const token = getToken();
+  return Response.json({ token });
+}
+
+export async function DELETE() {
+  deleteToken();
+  redirect("/");
+}

--- a/next-frontend/src/app/auth/actions.ts
+++ b/next-frontend/src/app/auth/actions.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+const AUTH_COOKIE = "auth_token";
+
+const TWO_WEEKS_MS = 12096e5;
+
+export async function setToken(token: string, rememberMe?: boolean) {
+  const expires = rememberMe ? new Date(Date.now() + TWO_WEEKS_MS) : undefined;
+  cookies().set(AUTH_COOKIE, token, { httpOnly: true, expires });
+}
+
+export async function getToken() {
+  return cookies().get(AUTH_COOKIE)?.value;
+}
+
+export async function deleteToken() {
+  cookies().delete(AUTH_COOKIE);
+}

--- a/next-frontend/src/app/auth/login/action.ts
+++ b/next-frontend/src/app/auth/login/action.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { z } from "zod";
+import { redirect } from "next/navigation";
+import { API_URL } from "src/constants";
+import { setToken } from "../actions";
+
+const AUTH_PATH = `/api-token-auth/`;
+
+export interface LoginFormState {
+  error: string | null;
+}
+
+const loginFormSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+  rememberMe: z.string().nullable(),
+});
+
+export async function login(
+  prevState: LoginFormState,
+  formData: FormData
+): Promise<LoginFormState> {
+  const username = formData.get("username");
+  const password = formData.get("password");
+  const rememberMe = formData.get("rememberMe");
+  const validInput = loginFormSchema.safeParse({
+    username,
+    password,
+    rememberMe,
+  });
+  try {
+    if (!validInput.success) {
+      throw new Error(validInput.error.toString());
+    }
+    const { username, password, rememberMe } = validInput.data;
+    const response = await fetch(API_URL + AUTH_PATH, {
+      body: JSON.stringify({ username, password }),
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    const { status, statusText } = response;
+    const { token, detail } = await response.json();
+    if (!response.ok || !token) {
+      let message = detail ?? statusText;
+      if (status === 400) {
+        message = "Invalid username or password. Please try again.";
+      }
+      throw new Error(message);
+    }
+    await setToken(token, Boolean(rememberMe));
+  } catch (error: Error | unknown) {
+    if (error instanceof Error) {
+      console.error(error);
+      return { error: error.message };
+    }
+    return { error: `Unexpected error: ${String(error)}` };
+  }
+  redirect("/");
+}

--- a/next-frontend/src/app/auth/login/page.tsx
+++ b/next-frontend/src/app/auth/login/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useFormState, useFormStatus } from "react-dom";
+import { login, LoginFormState } from "./action";
+
+function Submit({ children }: React.PropsWithChildren) {
+  const { pending } = useFormStatus();
+  return (
+    <button type='submit' aria-disabled={pending}>
+      {children}
+    </button>
+  );
+}
+
+export default function LoginPage() {
+  const [state, formAction] = useFormState<LoginFormState, FormData>(login, {
+    error: null,
+  });
+
+  return (
+    <div>
+      <form action={formAction}>
+        <label>
+          Username
+          <input type='text' name='username' required />
+        </label>
+        <label>
+          Password
+          <input type='password' name='password' required />
+        </label>
+        <label>
+          Remember Me <input type='checkbox' name='rememberMe' />
+        </label>
+        <Submit>Log In</Submit>
+      </form>
+      {state?.error && <p style={{ color: "red" }}>{state.error}</p>}
+    </div>
+  );
+}

--- a/next-frontend/src/app/layout.tsx
+++ b/next-frontend/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import { Inter } from "next/font/google";
 import "src/styles/globals.css";
+import Navigation from "src/components/Navigation";
+import { getToken } from "./auth/actions";
 
 const inter = Inter({ variable: "--font-inter", subsets: ["latin"] });
 
@@ -15,7 +17,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang='en' className={inter.variable}>
-      <body>{children}</body>
+      <body>
+        <Navigation />
+        {children}
+      </body>
     </html>
   );
 }

--- a/next-frontend/src/app/page.tsx
+++ b/next-frontend/src/app/page.tsx
@@ -3,17 +3,22 @@ import cx from "classnames";
 
 import { tools } from "src/data/tools";
 
-import color from "src/styles/color.module.css";
 import shape from "src/styles/shape.module.css";
-import text from "src/styles/text.module.css";
-import SiteName from "src/components/SiteName";
 import ToolGrid from "src/components/ToolGrid";
+import Link from "next/link";
+import { getToken } from "./auth/actions";
 
-export default function Home() {
+export default async function Home() {
+  const token = await getToken();
   return (
     <main className={cx(styles.page, shape.vh100)}>
-      <SiteName />
-      <ToolGrid tools={tools} />
+      {token ? (
+        <ToolGrid tools={tools} />
+      ) : (
+        <p>
+          <Link href='/auth/login'>Log in to view tools</Link>
+        </p>
+      )}
     </main>
   );
 }

--- a/next-frontend/src/components/Navigation/Navigation.tsx
+++ b/next-frontend/src/components/Navigation/Navigation.tsx
@@ -1,0 +1,14 @@
+import SiteName from "src/components/SiteName";
+import Link from "next/link";
+import { getToken } from "src/app/auth/actions";
+import LogOut from "../auth/LogOut";
+
+export default async function Navigation() {
+  const token = await getToken();
+  return (
+    <nav>
+      <SiteName />
+      {!token ? <Link href='/auth/login'>Log In</Link> : <LogOut />}
+    </nav>
+  );
+}

--- a/next-frontend/src/components/Navigation/index.ts
+++ b/next-frontend/src/components/Navigation/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Navigation";

--- a/next-frontend/src/components/auth/LogOut.tsx
+++ b/next-frontend/src/components/auth/LogOut.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function LogOut() {
+  const router = useRouter();
+  async function handleLogOut() {
+    await fetch("/api/token", { method: "DELETE" });
+    router.refresh();
+  }
+  return <button onClick={handleLogOut}>Log Out</button>;
+}

--- a/next-frontend/src/constants.ts
+++ b/next-frontend/src/constants.ts
@@ -1,0 +1,1 @@
+export const API_URL = "http://localhost:8000";

--- a/next-frontend/src/utils/endpoint.ts
+++ b/next-frontend/src/utils/endpoint.ts
@@ -1,0 +1,2 @@
+export const API_URL = "http://localhost:8000";
+export const AUTH_COOKIE = "auth_token";

--- a/next-frontend/tsconfig.json
+++ b/next-frontend/tsconfig.json
@@ -25,5 +25,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
- Uses Django REST Framework's token provider to exchange a username/password for an auth token.
- The frontend stores the token in a httpOnly session cookie, accessible only to server-side code. This lets us privately render components that rely on account permissions.
- Provides basic UI for login/logout, with polishing and refinements to come.
- Adds two API routes to help manage the state of the token cookie.

Other changes:
- Adds top-level `.gitignore` to avoid committing `.DS_Store` files
- Updates Docker compose with port mapping to access `localhost:3000` and `localhost:8000` during development
- Major version bump for Next.js to 14.0.4